### PR TITLE
Updating Conversant bid adapter URL to new 'cvx'

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -7,7 +7,7 @@ const GVLID = 24;
 export const storage = getStorageManager(GVLID);
 
 const BIDDER_CODE = 'conversant';
-const URL = 'https://web.hb.ad.cpe.dotomi.com/s2s/header/24';
+const URL = 'https://web.hb.ad.cpe.dotomi.com/cvx/client/hb/ortb/25';
 
 export const spec = {
   code: BIDDER_CODE,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Other

## Description of change
Updating endpoint url to new standard for Conversant

- contact email of the adapter’s maintainer: mediapsr@conversantmedia.com
- [ x] official adapter submission


## Other information
MPUB-14756 internal ticket number
author: Aaron Price
internal reviewers: Paul Yang, John Wier
